### PR TITLE
Stop camera tracking when moving the view

### DIFF
--- a/laserstudio/widgets/toolbars/zoomtoolbar.py
+++ b/laserstudio/widgets/toolbars/zoomtoolbar.py
@@ -68,7 +68,7 @@ class ZoomToolbar(QToolBar):
         w.setCheckable(True)
         w.setIconSize(QSize(24, 24))
         w.toggled.connect(lambda x: viewer.__setattr__("follow_stage_sight", x))
-        viewer.followStageSightChanged.connect(w.setChecked)
+        viewer.follow_stage_sight_changed.connect(w.setChecked)
         w.setChecked(True)
         self.addWidget(w)
 

--- a/laserstudio/widgets/viewer.py
+++ b/laserstudio/widgets/viewer.py
@@ -53,7 +53,7 @@ class Viewer(QGraphicsView):
     # Signal emitted when the mouse has moved in scene
     mouse_moved = pyqtSignal(float, float)
     # Signal emitted when the follow stage sight option changed
-    followStageSightChanged = pyqtSignal(bool)
+    follow_stage_sight_changed = pyqtSignal(bool)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -153,7 +153,7 @@ class Viewer(QGraphicsView):
         # Emit the signal if necessary
         if self._follow_stage_sight != value:
             self._follow_stage_sight = value
-            self.followStageSightChanged.emit(value)
+            self.follow_stage_sight_changed.emit(value)
 
     def reset_camera(self):
         """Resets the camera to show all elements of the scene"""


### PR DESCRIPTION
This pull request resolves issue #13 to stop tracking when the view is manually changed (right click)
It also changes the zoom toolbar association to a viewer instead of laserstudio