### PR TITLE
Scanning enable/disable interface button 

### DIFF
--- a/laserstudio/icons/no-scan.svg
+++ b/laserstudio/icons/no-scan.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   aria-hidden="true"
+   focusable="false"
+   data-prefix="fas"
+   data-icon="eye"
+   class="svg-inline--fa fa-eye fa-w-18"
+   role="img"
+   viewBox="0 0 20 20"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="no-scan.svg"
+   width="20"
+   height="20"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="28.480858"
+     inkscape:cx="9.3396063"
+     inkscape:cy="9.9540541"
+     inkscape:window-width="1800"
+     inkscape:window-height="1040"
+     inkscape:window-x="0"
+     inkscape:window-y="44"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <circle
+     style="fill:#000000;stroke:#ffffff;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2.2;stroke-opacity:0"
+     id="path1"
+     cx="10"
+     cy="10"
+     r="2.5" />
+</svg>

--- a/laserstudio/icons/scan.svg
+++ b/laserstudio/icons/scan.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   aria-hidden="true"
+   focusable="false"
+   data-prefix="fas"
+   data-icon="eye"
+   class="svg-inline--fa fa-eye fa-w-18"
+   role="img"
+   viewBox="0 0 20 20"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="scan.svg"
+   width="20"
+   height="20"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="28.480858"
+     inkscape:cx="9.3396063"
+     inkscape:cy="9.9540541"
+     inkscape:window-width="1800"
+     inkscape:window-height="1040"
+     inkscape:window-x="0"
+     inkscape:window-y="44"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <circle
+     style="fill:#000000;stroke:#ffffff;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2.2;stroke-opacity:0"
+     id="path1"
+     cx="10"
+     cy="10"
+     r="2.5" />
+  <circle
+     style="fill:#000000;stroke:#ffffff;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2.2;stroke-opacity:0"
+     id="path1-4"
+     cx="16"
+     cy="4"
+     r="2.5" />
+  <circle
+     style="fill:#000000;stroke:#ffffff;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2.2;stroke-opacity:0"
+     id="path1-4-3"
+     cx="3"
+     cy="3"
+     r="2.5" />
+  <circle
+     style="fill:#000000;stroke:#ffffff;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2.2;stroke-opacity:0"
+     id="path1-4-3-1"
+     cx="3.5"
+     cy="12.5"
+     r="2.5" />
+  <circle
+     style="fill:#000000;stroke:#ffffff;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2.2;stroke-opacity:0"
+     id="path1-4-3-1-1"
+     cx="7.5"
+     cy="17.5"
+     r="2.5" />
+  <circle
+     style="fill:#000000;stroke:#ffffff;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2.2;stroke-opacity:0"
+     id="path1-4-3-1-1-7"
+     cx="15.5"
+     cy="15.5"
+     r="2.5" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2.2;stroke-dasharray:none;stroke-opacity:1"
+     d="m 16,4 -6,6 -7,-7 0.5,9.5 4,5 8,-2"
+     id="path2"
+     sodipodi:nodetypes="cccccc" />
+</svg>

--- a/laserstudio/laserstudio.py
+++ b/laserstudio/laserstudio.py
@@ -198,9 +198,8 @@ class LaserStudio(QMainWindow):
         Triggers the viewer to perform changes to go to next step of scan.
         """
         v = {}
-        if self.scanning_enabled:
-            v.update(self.instruments.go_next())
-            v.update(self.viewer.go_next())
+        v.update(self.instruments.go_next())
+        v.update(self.viewer.go_next())
         return v
 
     def handle_screenshot(self, path: Optional[str] = None) -> Image.Image:

--- a/laserstudio/laserstudio.py
+++ b/laserstudio/laserstudio.py
@@ -46,6 +46,9 @@ class LaserStudio(QMainWindow):
         # Configuration file
         self.config = config
 
+        # Permits for the user to deactivate temporarly the go_next effect
+        self.scanning_enabled = True
+
         # User settings
         self.settings = QSettings("ledger", "laserstudio")
 
@@ -195,8 +198,9 @@ class LaserStudio(QMainWindow):
         Triggers the viewer to perform changes to go to next step of scan.
         """
         v = {}
-        v.update(self.instruments.go_next())
-        v.update(self.viewer.go_next())
+        if self.scanning_enabled:
+            v.update(self.instruments.go_next())
+            v.update(self.viewer.go_next())
         return v
 
     def handle_screenshot(self, path: Optional[str] = None) -> Image.Image:

--- a/laserstudio/restserver/server.py
+++ b/laserstudio/restserver/server.py
@@ -36,7 +36,9 @@ class RestProxy(QObject):
 
     @pyqtSlot(result="QVariant")
     def handle_go_next(self):
-        response = self.laser_studio.handle_go_next()
+        response = {}
+        if self.laser_studio.scanning_enabled:
+            response = self.laser_studio.handle_go_next()
         return QVariant(response)
 
     @pyqtSlot(result="QVariant")

--- a/laserstudio/widgets/coloredbutton.py
+++ b/laserstudio/widgets/coloredbutton.py
@@ -10,6 +10,7 @@ class ColoredPushButton(QPushButton):
     def __init__(
         self,
         icon_path: str,
+        pushed_icon_path: Optional[str] = None,
         color: Union[
             QColor, Qt.GlobalColor, int, LedgerColors
         ] = LedgerColors.SafetyOrange,
@@ -17,7 +18,7 @@ class ColoredPushButton(QPushButton):
     ):
         super().__init__(parent)
         self.normal_pixmap = colored_image(icon_path)
-        self.colored_pixmap = colored_image(icon_path, color=color)
+        self.colored_pixmap = colored_image(pushed_icon_path or icon_path, color=color)
         icon = QIcon()
         icon.addPixmap(self.normal_pixmap, QIcon.Mode.Normal, QIcon.State.Off)
         icon.addPixmap(self.colored_pixmap, QIcon.Mode.Normal, QIcon.State.On)

--- a/laserstudio/widgets/toolbars/scantoolbar.py
+++ b/laserstudio/widgets/toolbars/scantoolbar.py
@@ -40,9 +40,9 @@ class ScanToolbar(QToolBar):
         w.clicked.connect(laser_studio.handle_go_next)
         self.addWidget(w)
 
-        # Scanning enable/disable button
+        # Scanning from LSAPI enable/disable button
         w = ColoredPushButton(":/icons/no-scan.svg", ":/icons/scan.svg", parent=self)
-        w.setToolTip("Enable/Disable scanning")
+        w.setToolTip("Enable or block the go_next commands from LSAPI.")
         w.setIconSize(QSize(24, 24))
         w.setCheckable(True)
         w.setChecked(laser_studio.scanning_enabled)

--- a/laserstudio/widgets/toolbars/scantoolbar.py
+++ b/laserstudio/widgets/toolbars/scantoolbar.py
@@ -40,6 +40,15 @@ class ScanToolbar(QToolBar):
         w.clicked.connect(laser_studio.handle_go_next)
         self.addWidget(w)
 
+        # Scanning enable/disable button
+        w = ColoredPushButton(":/icons/no-scan.svg", ":/icons/scan.svg", parent=self)
+        w.setToolTip("Enable/Disable scanning")
+        w.setIconSize(QSize(24, 24))
+        w.setCheckable(True)
+        w.setChecked(laser_studio.scanning_enabled)
+        w.toggled.connect(lambda v: laser_studio.__setattr__("scanning_enabled", v))
+        self.addWidget(w)
+
         # Density
         w = self.density = ReturnSpinBox()
         w.setToolTip(


### PR DESCRIPTION
To allow to block temporarily the go_next() effect from LSAPI calls, Shortcut (Ctrl + Space) and Go next button in Toolbar.