### PR TITLE
Resolve issue on crash for set_position with wrong number of axes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,14 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "LaserStudio Dummy",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "laserstudio",
+            "args": ["--config", "config.dummy.example.yaml"]
+        },
+
+        {
             "name": "LaserStudio",
             "type": "debugpy",
             "request": "launch",

--- a/config.dummy.example.yaml
+++ b/config.dummy.example.yaml
@@ -11,6 +11,7 @@ stage:
   refresh_interval_ms: 100
   type: Dummy
   unit_factor: 1000
+  num_axis: 3
 probes:
   - enable: true
     label: "Dummy Probe"

--- a/laserstudio/instruments/stage.py
+++ b/laserstudio/instruments/stage.py
@@ -218,7 +218,7 @@ class StageInstrument(Instrument):
         :return: Get the position of the stage
         """
         self.mutex.lock()
-        position = self.stage.position
+        position = Vector(*self.stage.position.data)
         self.mutex.unlock()
 
         # Apply shearing transformation

--- a/laserstudio/instruments/stage.py
+++ b/laserstudio/instruments/stage.py
@@ -246,6 +246,7 @@ class StageInstrument(Instrument):
         for i in range(len(position)):
             position[i] = position[i] * factors[i] + self.offset_origin[i]
 
+        position = Vector(*position)
         self.position_changed.emit(position)
         return position
 

--- a/laserstudio/instruments/stage.py
+++ b/laserstudio/instruments/stage.py
@@ -173,26 +173,38 @@ class StageInstrument(Instrument):
             list[float], config.get("unit_factor", config.get("unit_factors", [1.0]))
         )
         position = self.stage.position
-        if type(factors) is not list:
-            factors = [factors] * len(position)
-        else:
-            # We ensure that there is at least one element in the array
+        if isinstance(factors, int) or isinstance(factors, float):
+            logging.getLogger("laserstudio").warning(
+                f"Unit factor {factors} is a single value, it will be repeated for all axes."
+            )
+            factors = [float(factors)] * len(position)
+        
+        if len(factors) != len(position):
+            logging.getLogger("laserstudio").warning(
+                f"Unit factors {factors} has an inconsistent length from the number of axes ({len(position)}). Please check your configuration file"
+            )
             if len(factors) == 0:
-                factors = [1.0]
+                logging.getLogger("laserstudio").warning(
+                    "No unit factors provided. 1.0 will be repeated for all axes."
+                )
+                factors = [1.0] * len(position)
+            
+            if len(factors) < len(position):
+                last_value = factors[-1]
+                logging.getLogger("laserstudio").warning(
+                    f"Last value ({last_value}) will be repeated to the number of axes."
+                )
+                factors = factors + [last_value] * (len(position) - len(factors))
+            
+            if len(factors) > len(position):
+                # Truncate array if there is too much values for the number of axes
+                logging.getLogger("laserstudio").warning(
+                    f"Values will be truncated to the number of axes"
+                )
+                factors = factors[: len(position)]
+                
+        self.unit_factors: list[float] = factors
 
-            # Truncate array if there is too much values for the number of axes
-            factors = factors[: len(position)]
-
-            # Completion with last value of the array until we get enough number of values
-            factors += [factors[-1]] * abs(len(position) - len(factors))
-
-        self.unit_factors = factors
-
-        assert type(self.unit_factors) is list and len(self.unit_factors) == len(
-            position
-        ), (
-            f"Unit factor {self.unit_factors} is neither an number nor a list of numbers. Please check your configuration file"
-        )
 
         # Offset origin
         self.offset_origin: list[float] = cast(
@@ -218,18 +230,19 @@ class StageInstrument(Instrument):
         :return: Get the position of the stage
         """
         self.mutex.lock()
-        position = Vector(*self.stage.position.data)
+        position = cast(list[float], self.stage.position.data)
         self.mutex.unlock()
 
         # Apply shearing transformation
-        x = float(position[0])
-        y = float(position[1])
+        x = position[0]
+        y = position[1]
 
         position[0] = x - self.shear[0] * y
         position[1] = y - self.shear[1] * x
 
         factors = self.unit_factors
-        assert type(factors) is list and len(factors) == len(position)
+        if isinstance(factors, float) or isinstance(factors, int):
+            factors = [float(factors)] * len(position)
         for i in range(len(position)):
             position[i] = position[i] * factors[i] + self.offset_origin[i]
 

--- a/laserstudio/instruments/stage.py
+++ b/laserstudio/instruments/stage.py
@@ -305,6 +305,16 @@ class StageInstrument(Instrument):
             If there is a configuration of z-offsetting for each move, it will be done and
             intermediates moves are blocking (eg, waiting to be done).
         """
+        # Make sure about the dimension of the position vector
+        if len(position) > self.num_axis:
+            logging.getLogger("laserstudio").warning(f"Position dimension {len(position)} is greater than the number of axes {self.num_axis}. Extra axes will be ignored.")
+            position = Vector(*position.data[:self.num_axis])
+        elif len(position) < self.num_axis:
+            logging.getLogger("laserstudio").warning(f"Position dimension {len(position)} is less than the number of axes {self.num_axis}. Missing axes will be set to their current position.")
+            current_position = self.position
+            extra_positions = [current_position[i] for i in range(len(position), self.num_axis)]
+            position = Vector(*(position.data + extra_positions))
+
         logging.getLogger("laserstudio").debug(f"Moving to {position}...")
         if self.guardrail_enabled:
             displacement = self.position - position

--- a/laserstudio/instruments/stage.py
+++ b/laserstudio/instruments/stage.py
@@ -18,6 +18,7 @@ from .stage_rest import StageRest
 from .stage_dummy import StageDummy
 from .list_serials import get_serial_device, DeviceSearchError
 from .instrument import Instrument
+from copy import deepcopy
 
 __all__ = [
     "StageInstrument",
@@ -165,7 +166,7 @@ class StageInstrument(Instrument):
 
         if self.refresh_interval is not None:
             QTimer.singleShot(
-                self.refresh_interval, Qt.TimerType.CoarseTimer, self.refresh_stage
+                self.refresh_interval, Qt.TimerType.CoarseTimer, self.__autorefresh_stage
             )
 
         # Unit factor to apply in order to get coordinates in micrometers
@@ -230,15 +231,15 @@ class StageInstrument(Instrument):
         :return: Get the position of the stage
         """
         self.mutex.lock()
-        position = cast(list[float], self.stage.position.data)
+        position = deepcopy(self.stage.position)
         self.mutex.unlock()
 
         # Apply shearing transformation
-        x = position[0]
-        y = position[1]
+        x = float(position.x)
+        y = float(position.y)
 
-        position[0] = x - self.shear[0] * y
-        position[1] = y - self.shear[1] * x
+        position.x = x - self.shear[0] * y
+        position.y = y - self.shear[1] * x
 
         factors = self.unit_factors
         if isinstance(factors, float) or isinstance(factors, int):
@@ -246,7 +247,6 @@ class StageInstrument(Instrument):
         for i in range(len(position)):
             position[i] = position[i] * factors[i] + self.offset_origin[i]
 
-        position = Vector(*position)
         self.position_changed.emit(position)
         return position
 
@@ -263,8 +263,9 @@ class StageInstrument(Instrument):
         """
         self.move_to(value, wait=False)
 
-    def refresh_stage(self):
-        """Called regularly to get stage position, and emits a pyQtSignal"""
+    def __autorefresh_stage(self):
+        """Called regularly to get stage position, and emits a pyQtSignal
+        This method is not public, it is called by a QTimer to refresh the stage position regularly."""
         try:
             self.position_changed.emit(position := self.position)
             logging.getLogger("laserstudio").debug(f"Position refreshed: {position}")
@@ -274,7 +275,7 @@ class StageInstrument(Instrument):
             )
         if self.refresh_interval is not None:
             QTimer.singleShot(
-                self.refresh_interval, Qt.TimerType.CoarseTimer, self.refresh_stage
+                self.refresh_interval, Qt.TimerType.CoarseTimer, self.__autorefresh_stage
             )
 
     def move_relative(self, displacement: Vector, wait: bool, backlash: bool = False):

--- a/laserstudio/instruments/stage_dummy.py
+++ b/laserstudio/instruments/stage_dummy.py
@@ -21,7 +21,8 @@ class StageDummy(Stage):
 
     @property
     def position(self) -> Vector:
-        return self._position
+        # Do not return the object itself, but a copy
+        return Vector(*cast(list[float], self._position.data))
 
     @position.setter
     def position(self, value: Vector):

--- a/laserstudio/instruments/stage_dummy.py
+++ b/laserstudio/instruments/stage_dummy.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from .stage import Stage, Vector
-from typing import cast, TYPE_CHECKING
+from typing import cast, TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .stage import StageInstrument
@@ -8,7 +10,7 @@ if TYPE_CHECKING:
 class StageDummy(Stage):
     """Class to implement Dummy Stage"""
 
-    def __init__(self, config: dict, stage_instrument: "StageInstrument"):
+    def __init__(self, config: dict[str, Any], stage_instrument: StageInstrument):
         """
         :param config: YAML configuration object
         :param stage_instrument: The StageInstrument the Stage is attached to.
@@ -24,7 +26,6 @@ class StageDummy(Stage):
     @position.setter
     def position(self, value: Vector):
         self._position = value
-        self.stage_instrument.refresh_stage()
 
     @property
     def is_moving(self) -> bool:

--- a/laserstudio/laserstudio.py
+++ b/laserstudio/laserstudio.py
@@ -1,4 +1,11 @@
 #!/usr/bin/python3
+import os
+import logging
+import yaml
+from PIL import Image, ImageQt
+import numpy
+from collections.abc import Sequence
+from typing import Any, cast
 from PyQt6.QtCore import Qt, QKeyCombination, QSettings
 from PyQt6.QtGui import (
     QColor,
@@ -9,7 +16,6 @@ from PyQt6.QtGui import (
     QColorConstants,
 )
 from PyQt6.QtWidgets import QMainWindow, QButtonGroup
-from typing import Any
 from .widgets.viewer import Viewer
 from .instruments.instruments import (
     Instruments,
@@ -19,11 +25,6 @@ from .instruments.instruments import (
     CameraRaptorInstrument,
     LightInstrument,
 )
-import logging
-import yaml
-from PIL import Image, ImageQt
-import numpy
-
 from .instruments.stage import Vector
 from .widgets.toolbars import (
     PictureToolBar,
@@ -405,12 +406,31 @@ class LaserStudio(QMainWindow):
             return {"settings": inst.settings}
         return None
 
-    def handle_position(self, pos: list[float] | None) -> dict[str, Any]:
+    def handle_position(self, pos: Sequence[float] | None) -> dict[str, Any]:
         if self.instruments.stage is None:
             return {"pos": []}
+        stage = self.instruments.stage
         if pos is not None:
-            self.instruments.stage.move_to(Vector(*pos), wait=True)
-        return {"pos": self.instruments.stage.position.data}
+            if not isinstance(pos, (list, tuple)):
+                current_pos = cast(list[float], stage.position.data)
+                return {
+                    "error": "Invalid position: expected a list of coordinates",
+                    "pos": current_pos,
+                }
+            num_axis = stage.num_axis
+            if len(pos) > num_axis:
+                current_pos = cast(list[float], stage.position.data)
+                return {
+                    "error": "Too many coordinates for stage axes",
+                    "pos": current_pos,
+                }
+            if len(pos) < num_axis:
+                target = list(cast(list[float], stage.position.data))
+                for i, value in enumerate(pos):
+                    target[i] = value
+                pos = target
+            stage.move_to(Vector(*pos), wait=True)
+        return {"pos": cast(list[float], stage.position.data)}
 
     def handle_markers(self) -> list[dict[str, Any]]:
         """Handle a Markers API request to get the list of markers."""

--- a/laserstudio/lsapi/lsapi.py
+++ b/laserstudio/lsapi/lsapi.py
@@ -235,7 +235,11 @@ class LSAPI:
         """
         Requests the main stage to move to position the current focused object to given coordinates.
         This waits for the stage to end of move, returns the final coordinates of the stage.
-        These coordinates may be different from the requested one (if the focused element has a delta).
+        Final coordinates may be different from the requested one.
+
+        Note that position is a list of elements, that may be different from the number of axes of the stage.
+        If the number of elements is less than the number of axes, the missing elements (axes) are not moved.
+        If the number of elements is greater than the number of axes, the extra elements are ignored.
 
         :param pos: the position to reach.
         :return: the final coordinates of the stage.

--- a/laserstudio/lsapi/lsapi.py
+++ b/laserstudio/lsapi/lsapi.py
@@ -2,6 +2,7 @@
 # Unlike laserstudio, this library does not require PyQt being installed
 # (this is why it is separated from the laserstudio server code).
 from typing import Any
+from numpy.typing import NDArray
 import requests
 from PIL import Image
 import io
@@ -171,7 +172,7 @@ class LSAPI:
             # In this case, the actual returned thing is a one-pixel image placeholder
             self.send("images/camera", {"path": path})
 
-    def accumulated_image(self, path: str | None) -> numpy.ndarray | None:
+    def accumulated_image(self, path: str | None) -> NDArray[Any] | None:
         """
         Get the camera accumulator's data, as a numpy array.
         """
@@ -200,7 +201,7 @@ class LSAPI:
 
     def reference_image(
         self, num: int | None = None, unset: bool = False, set: bool = False
-    ) -> numpy.ndarray | None:
+    ) -> NDArray[Any] | None:
         """
         Get and/or set the reference image for the camera.
         """

--- a/laserstudio/restserver/server.py
+++ b/laserstudio/restserver/server.py
@@ -429,7 +429,11 @@ class Position(Resource):
         json = flask.request.json
         if not isinstance(json, dict):
             return "Given value is not a dictionary", 415
-        return RestServer.invoke("handle_position", QVariant(pos))
+        pos = json.get("pos")
+        response = cast(dict, RestServer.invoke("handle_position", QVariant(pos)))
+        if "error" in response:
+            return response, HTTPStatus.BAD_REQUEST
+        return response
 
     @motion.response(200, "Stage position and moving state", position_move)
     def get(self):

--- a/tests/test_lsapi_annotations.py
+++ b/tests/test_lsapi_annotations.py
@@ -1,6 +1,5 @@
 from laserstudio.lsapi import LSAPI
 from random import random
-import numpy
 
 
 def test_add_marker():
@@ -61,36 +60,3 @@ def test_get_markers() -> None:
     assert all("id" in marker for marker in markers)
     assert all("pos" in marker for marker in markers)
     assert all("color" in marker for marker in markers)
-
-
-def test_go_next():
-    api = LSAPI()
-    api.go_next()
-
-
-def test_get_settings():
-    api = LSAPI()
-    assert api.instrument_settings("test") is not None
-    assert api.instrument_settings("test2") is None
-
-
-def test_set_settings():
-    api = LSAPI()
-    api.instrument_settings("test", {"settings": {"label": "TOTO"}})
-
-
-def test_get_accumulated_image():
-    api = LSAPI()
-    image = api.accumulated_image(None)
-    assert image is not None
-    assert isinstance(image, numpy.ndarray)
-
-
-def test_autofocus_register():
-    api = LSAPI()
-    api.autofocus()
-
-
-def test_magicfocus():
-    api = LSAPI()
-    api.magicfocus()

--- a/tests/test_lsapi_focus.py
+++ b/tests/test_lsapi_focus.py
@@ -1,0 +1,11 @@
+from laserstudio.lsapi import LSAPI
+
+
+def test_autofocus_register():
+    api = LSAPI()
+    api.autofocus()
+
+
+def test_magicfocus():
+    api = LSAPI()
+    api.magicfocus()

--- a/tests/test_lsapi_imaging.py
+++ b/tests/test_lsapi_imaging.py
@@ -1,0 +1,10 @@
+from laserstudio.lsapi import LSAPI
+import numpy
+from typing import cast
+
+def test_get_accumulated_image():
+    api = LSAPI()
+    image = api.accumulated_image(None)
+    assert image is not None
+    image = cast(numpy.ndarray, image)
+    assert isinstance(image, numpy.ndarray)

--- a/tests/test_lsapi_motion.py
+++ b/tests/test_lsapi_motion.py
@@ -1,0 +1,67 @@
+from laserstudio.lsapi import LSAPI
+import numpy
+import pytest
+from typing import Any, cast
+
+
+def test_go_next():
+    api = LSAPI()
+    api.go_next()
+
+
+def test_get_settings():
+    api = LSAPI()
+    assert api.instrument_settings("test") is not None
+    assert api.instrument_settings("test2") is None
+
+
+def test_set_settings():
+    api = LSAPI()
+    api.instrument_settings("test", {"settings": {"label": "TOTO"}})
+
+
+def test_get_accumulated_image():
+    api = LSAPI()
+    image = api.accumulated_image(None)  # type: ignore
+    assert image is not None
+    assert isinstance(image, numpy.ndarray)
+
+
+
+def test_go_to_position_shorter_coordinates():
+    api = LSAPI()
+    current = api.position()
+    if not current or len(current) < 2:
+        pytest.skip("Need at least 2 axes to test partial move")
+    partial = list(current[:-1])
+    partial[0] = float(partial[0]) + 1.0
+    result = cast(dict[str, Any], api.go_to_position(partial))
+    assert "error" not in result
+    assert "pos" in result
+    new_pos = cast(list[float], result["pos"])
+    assert len(new_pos) == len(current)
+    tolerance = 1e-6
+    for i, value in enumerate(partial):
+        assert abs(new_pos[i] - value) <= tolerance
+    assert abs(new_pos[-1] - current[-1]) <= tolerance
+
+
+def test_go_to_position_too_many_coordinates():
+    api = LSAPI()
+    current = api.position()
+    if not current:
+        pytest.skip("No stage available")
+    new_pos = list(current)
+    new_pos[0] += 1.0
+    too_long = new_pos + [0.0]
+    response = api.send("motion/position", {"pos": too_long}, is_put=True)
+    assert response.status_code == 400
+    result = cast(dict[str, Any], response.json())
+    assert "error" in result
+    assert "pos" in result
+    final_pos = cast(list[float], result["pos"])
+    tolerance = 1e-6
+    assert len(final_pos) == len(current)
+    for i, value in enumerate(current):
+        assert abs(final_pos[i] - value) <= tolerance
+    

--- a/tests/test_lsapi_settings.py
+++ b/tests/test_lsapi_settings.py
@@ -1,0 +1,16 @@
+from laserstudio.lsapi import LSAPI
+
+def test_get_settings():
+    api = LSAPI()
+    settings = api.instrument_settings("Dummy Probe")
+    assert settings is not None
+    assert settings["label"] == "Dummy Probe"
+    assert settings["offset_pos"] == [0, 0]
+
+
+def test_set_settings():
+    api = LSAPI()
+    api.instrument_settings("Dummy Probe", {"settings": {"label": "TOTO"}})
+    settings = api.instrument_settings("Dummy Probe")
+    assert settings is not None
+    assert settings["label"] == "TOTO"


### PR DESCRIPTION
To resolve a crash when the lsapi.set_position is called with a smaller array for the destination coordinates.
The problem is present within the logic of the StageInstrument
Also solve a double issue for DummyStage, where the internal object storing the position is altered out of the object.